### PR TITLE
Split preview workflow to support fork PRs

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -1,4 +1,4 @@
-name: Deploy PR previews
+name: Build PR preview
 
 on:
   pull_request:
@@ -10,26 +10,45 @@ on:
 
 concurrency: preview-${{ github.ref }}
 
-
 jobs:
-  deploy-preview:
+  build-preview:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Save PR metadata
+        run: |
+          echo "${{ github.event.number }}" > pr-number.txt
+          echo "${{ github.event.action }}" > pr-action.txt
+
+      - name: Upload PR metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-metadata
+          path: |
+            pr-number.txt
+            pr-action.txt
+          retention-days: 1
+
       - name: Set up Python 3.11
+        if: github.event.action != 'closed'
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - run: pip install -r requirements.txt
+
+      - name: Install dependencies
+        if: github.event.action != 'closed'
+        run: pip install -r requirements.txt
 
       - name: Build
+        if: github.event.action != 'closed'
         run: ./build.sh
 
-      - name: Deploy preview
-        uses: rossjrw/pr-preview-action@v1
+      - name: Upload build artifact
+        if: github.event.action != 'closed'
+        uses: actions/upload-artifact@v4
         with:
-          source-dir: ./build/html
-          deploy-repository: OasisLMF/PreviewDocs
-          token: ${{ secrets.BUILD_PREVIEW_TOKEN }}
+          name: preview-build
+          path: build/html
+          retention-days: 1

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,49 @@
+name: Deploy PR previews
+
+on:
+  workflow_run:
+    workflows:
+      - Build PR preview
+    types:
+      - completed
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-22.04
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download PR metadata
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-metadata
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Read PR metadata
+        id: meta
+        run: |
+          echo "pr_number=$(cat pr-number.txt)" >> $GITHUB_OUTPUT
+          ACTION=$(cat pr-action.txt)
+          if [ "$ACTION" = "closed" ]; then
+            echo "deploy_action=remove" >> $GITHUB_OUTPUT
+          else
+            echo "deploy_action=deploy" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Download build artifact
+        if: steps.meta.outputs.deploy_action == 'deploy'
+        uses: actions/download-artifact@v4
+        with:
+          name: preview-build
+          path: build/html
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./build/html
+          deploy-repository: OasisLMF/PreviewDocs
+          token: ${{ secrets.BUILD_PREVIEW_TOKEN }}
+          action: ${{ steps.meta.outputs.deploy_action }}
+          pr-number: ${{ steps.meta.outputs.pr_number }}


### PR DESCRIPTION
Closes #51

## Summary
- Splits the single `build-preview.yml` workflow into two: a build step and a deploy step
- Build runs on `pull_request` (no secrets needed — safe for forks)
- Deploy runs on `workflow_run` after build completes (runs in base repo context, has access to secrets)
- PRs from external forks will now get preview deployments without needing repo access

## Why
GitHub doesn't pass secrets to workflows triggered by fork PRs (security measure). The previous single workflow broke for any external contributor's PR.

## Test plan
- [ ] Verify a fork PR triggers the build workflow successfully
- [ ] Verify the deploy workflow runs after and deploys the preview
- [ ] Verify closing a fork PR removes the preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)